### PR TITLE
feat: add resolution option and default resolution logic

### DIFF
--- a/embedders/dot.lua
+++ b/embedders/dot.lua
@@ -8,7 +8,7 @@ local embedder = pl.class(base)
 embedder._name = "embedders.dot"
 
 function embedder.conversionCommand(_, options)
-  local resolution = SU.cast("integer", options.resolution or 300)
+  local resolution = SU.cast("integer", options.resolution)
   local width = options.width and SILE.measurement(options.width):tonumber()
   local height = options.height and SILE.measurement(options.height):tonumber()
   local layout = options.layout

--- a/embedders/lilypond.lua
+++ b/embedders/lilypond.lua
@@ -52,7 +52,7 @@ function embedder.preambleContent(_, options)
 end
 
 function embedder.conversionCommand(_, options)
-  local resolution = SU.cast("integer", options.resolution or 300)
+  local resolution = SU.cast("integer", options.resolution)
   local dpi = string.format("-dresolution=%f", resolution)
 
   -- Build lilypond conversion command
@@ -90,7 +90,7 @@ leaving Lilypond apply its usual logic, whether systems end at their natural hor
 length or fill the line width.}
 \item{\autodoc:parameter{raggedlast=<boolean>} is absent by default,
 leaving Lilypond apply its usual logic, whether the last system in the score ends at
-its natural horizonal length or fills the line width.}
+its natural horizontal length or fills the line width.}
 \end{itemize}
 
 Note that the output is generated as a single cropped image, disregarding pages.


### PR DESCRIPTION
Closes #1 since the resolution is no longer hard-coded without ways for changing it. (But 300 DPI is still the default if the resolution is not specified at all.)

N.B. A the time of writing, the resilient classes don't have a resolution option contrary to what the documentation says. It's coming soon, though.